### PR TITLE
 Use composefs crate for fsverity digest reading

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,17 +10,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  build-fedora:
     runs-on: ubuntu-24.04
+    container:
+      image: quay.io/fedora/fedora:41
+      options: "--privileged --pid=host -v /var/tmp:/var/tmp -v /:/run/host"
 
     steps:
+    - run: dnf -y install cargo clippy composefs-devel e2fsprogs
     - name: Enable fs-verity on /
-      run: sudo tune2fs -O verity $(findmnt -vno SOURCE /)
+      run: tune2fs -O verity $(findmnt -vno SOURCE /run/host)
     - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Clippy
       run: cargo clippy
     - name: Run tests
-      run: cargo test --verbose
+      run: env CFS_TEST_TMPDIR=/run/host/var/tmp cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { version = "1.0.89", features = ["backtrace"] }
 async-compression = { version = "0.4.17", features = ["tokio", "gzip", "zstd"] }
 clap = { version = "4.5.19", features = ["derive"] }
 containers-image-proxy = "0.7.0"
+composefs = "0.1.3"
 hex = "0.4.3"
 indicatif = { version = "0.17.8", features = ["tokio"] }
 oci-spec = "0.7.0"


### PR DESCRIPTION
tests: Add support for CFS_TEST_TMPDIR

Because we require fsverity in the tests, make this easy
to configure externally for different test harnesses to use.

Signed-off-by: Colin Walters <walters@verbum.org>

---

ci: Switch to using Fedora in a container

Prep for linking to the composefs crate and C shared library
to ensure we share code and maintain an incentive to contribute
to those.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Use composefs crate for fsverity digest reading

To increase the motivation to improve that crate and the C library;
especially the C library, because we *must* have it anyways because
we depend on the binaries and we are just not going to rewrite
everything in Rust in the near future.

(And if we *did* start a rewrite of the composefs core I think
 that rewrite should live in that repo, not this one)

Signed-off-by: Colin Walters <walters@verbum.org>

---